### PR TITLE
Fix SDK publish targeting npm registry instead of GitHub Packages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
         run: npm --prefix sdk run build
 
       - name: Publish to GitHub Packages
-        run: npm --prefix sdk publish
+        run: npm publish
+        working-directory: sdk
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `npm --prefix sdk publish` was running from the root directory, causing npm to pick up the root `package.json` (`qrapid-api@1.0.0`) and ignore `sdk/publishConfig`
- This resulted in a publish attempt to `registry.npmjs.org` instead of `npm.pkg.github.com`, failing with `ENEEDAUTH`
- Fixed by replacing `--prefix sdk` with `working-directory: sdk` so npm resolves `sdk/package.json` and its `publishConfig.registry` correctly

## Test plan

- [ ] Merge and verify the `sdk` job completes successfully on the next push to `main`
- [ ] Confirm the package `@libre-net-pe/qrapid-sdk` appears under GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)