### PR TITLE
Replace folderId with embedded folder object in QR code responses

### DIFF
--- a/openapi/components/schemas/DynamicQrCode.yaml
+++ b/openapi/components/schemas/DynamicQrCode.yaml
@@ -73,13 +73,11 @@ properties:
     format: date-time
     nullable: true
     example: null
-  folderId:
-    description: >
-      ID of the folder this dynamic QR code belongs to. Null means the code is unfiled.
-      Use `PATCH /dynamic-qr-codes/{id}` to move a code between folders.
-    type: string
+  folder:
+    description: "The folder this code belongs to. Null means the code is unfiled."
     nullable: true
-    example: fol_abc123
+    allOf:
+      - $ref: ./FolderSummary.yaml
   branding:
     description: Branding configuration applied at generation time. Null if the QR code was generated without custom branding.
     type: object

--- a/openapi/components/schemas/FolderSummary.yaml
+++ b/openapi/components/schemas/FolderSummary.yaml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - id
+  - name
+properties:
+  id:
+    type: string
+    example: fol_abc123
+  name:
+    type: string
+    example: Marketing Campaign

--- a/openapi/components/schemas/QrCode.yaml
+++ b/openapi/components/schemas/QrCode.yaml
@@ -33,13 +33,11 @@ properties:
     type: string
     format: uri
     example: 'https://cdn.qrapid.io/qr/qr_abc123xyz.png'
-  folderId:
-    description: >
-      ID of the folder this QR code belongs to. Null means the code is unfiled.
-      Use `PATCH /qr-codes/{id}` to move a code between folders.
-    type: string
+  folder:
+    description: "The folder this code belongs to. Null means the code is unfiled."
     nullable: true
-    example: fol_abc123
+    allOf:
+      - $ref: ./FolderSummary.yaml
   branding:
     description: Branding configuration applied at generation time. Null if the QR code was generated without custom branding.
     type: object


### PR DESCRIPTION
## Summary

- Adds `FolderSummary` schema (`id` + `name`) to `openapi/components/schemas/`
- Replaces the bare `folderId: string` field in `QrCode` and `DynamicQrCode` with a nullable `folder` object referencing `FolderSummary`
- All six read endpoints are affected automatically via schema inheritance (`GET`/`PATCH` for both resource types, and both list endpoints)
- Request schemas (`QrCodeCreateRequest`, `DynamicQrCodeCreateRequest`, `DynamicQrCodeUpdateRequest`) are **unchanged** — they still accept `folderId` as a string input

## Test plan

- [ ] `npm test` passes with 0 errors, 0 warnings
- [ ] `npm start` — Redoc preview shows `folder` object with `id` and `name` instead of `folderId` in both QR code schemas
- [ ] Create/update request schemas still show `folderId` as a plain string input field

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)