### PR TITLE
Fix nullable folder property missing type field in QrCode schemas

### DIFF
--- a/openapi/components/schemas/DynamicQrCode.yaml
+++ b/openapi/components/schemas/DynamicQrCode.yaml
@@ -75,6 +75,7 @@ properties:
     example: null
   folder:
     description: "The folder this code belongs to. Null means the code is unfiled."
+    type: object
     nullable: true
     allOf:
       - $ref: ./FolderSummary.yaml

--- a/openapi/components/schemas/QrCode.yaml
+++ b/openapi/components/schemas/QrCode.yaml
@@ -35,6 +35,7 @@ properties:
     example: 'https://cdn.qrapid.io/qr/qr_abc123xyz.png'
   folder:
     description: "The folder this code belongs to. Null means the code is unfiled."
+    type: object
     nullable: true
     allOf:
       - $ref: ./FolderSummary.yaml


### PR DESCRIPTION
## Summary

- `QrCode.yaml` and `DynamicQrCode.yaml` both had `nullable: true` on the `folder` property without a `type` field
- `openapi-typescript` enforces that `nullable` must be paired with an explicit `type`, causing the `sdk:generate` step to throw an error and fail CI
- Added `type: object` to the `folder` property in both schemas, consistent with how `branding` is already defined in the same files

## Test plan

- [x] `npm run sdk:generate` completes successfully with no errors
- [x] `npm --prefix sdk run build` produces ESM, CJS, and `.d.ts` outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)