### PR TITLE
ci: auto-bump SDK version on every publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,9 @@ jobs:
   sdk:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,6 +102,18 @@ jobs:
 
       - name: Generate TypeScript types
         run: npm run sdk:generate
+
+      - name: Bump SDK version
+        run: npm version patch --no-git-tag-version
+        working-directory: sdk
+
+      - name: Commit and push version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add sdk/package.json sdk/package-lock.json
+          git commit -m "chore: bump SDK version [skip ci]"
+          git push origin HEAD:${{ github.ref_name }}
 
       - name: Install SDK dependencies
         run: npm --prefix sdk ci


### PR DESCRIPTION
## Summary

- Adds a **Bump SDK version** step (`npm version patch --no-git-tag-version`) to the `sdk` CI job before publishing, so a new patch version is cut on every run
- Adds a **Commit and push version bump** step that commits the updated `sdk/package.json` and `sdk/package-lock.json` back to the branch using `[skip ci]` to prevent an infinite workflow loop
- Adds explicit per-job `permissions` (`contents: write`, `packages: write`) to the `sdk` job — previously the top-level `contents: read` blocked the bot push

## Test plan

- [ ] Merge to `main` and verify the `sdk` job bumps the version (e.g. `0.1.0` → `0.1.1`), commits it back, and publishes successfully to GitHub Packages
- [ ] Confirm the auto-commit does **not** re-trigger the workflow (check for `[skip ci]` in the commit message)
- [ ] Verify subsequent merges keep incrementing the patch version

🤖 Generated with [Claude Code](https://claude.com/claude-code)