### PR TITLE
fix(ci): scope GitHub Packages registry to @libre-net-pe in sdk job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,7 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://npm.pkg.github.com
+          scope: '@libre-net-pe'
 
       - name: Install root dependencies
         run: npm ci


### PR DESCRIPTION
Without a scope, actions/setup-node wrote a global .npmrc entry that
redirected ALL npm installs to https://npm.pkg.github.com. Public
packages like @redocly/openapi-cli, openapi-typescript, and
openapi-fetch are on npmjs.com and not available on GitHub Packages,
so every npm ci step in the sdk job failed with a 404.

Adding scope: '@libre-net-pe' scopes the registry override to only
@libre-net-pe/* packages. Public packages install from npmjs.com as
before, and npm publish still targets GitHub Packages via
publishConfig.registry in sdk/package.json.

https://claude.ai/code/session_01CUcaWVWtu3GrcW6WiqDNtF