### PR TITLE
feat(assets): add GET /assets/logo endpoint to list logos

### DIFF
--- a/openapi/components/schemas/LogoSummary.yaml
+++ b/openapi/components/schemas/LogoSummary.yaml
@@ -1,0 +1,20 @@
+description: Logo asset metadata returned in list responses.
+type: object
+required:
+  - logoId
+  - filename
+  - createdAt
+properties:
+  logoId:
+    description: Unique identifier for the logo, prefixed with `logo_`. Pass this as `branding.logoId` when creating a QR code.
+    type: string
+    example: logo_xyz789
+  filename:
+    description: Original filename provided at upload time.
+    type: string
+    example: company-logo.png
+  createdAt:
+    description: ISO 8601 timestamp of when the logo was originally uploaded.
+    type: string
+    format: date-time
+    example: '2026-02-18T12:00:00Z'

--- a/openapi/components/schemas/PaginatedLogos.yaml
+++ b/openapi/components/schemas/PaginatedLogos.yaml
@@ -1,0 +1,31 @@
+description: Paginated list of logo assets.
+type: object
+required:
+  - data
+  - pagination
+properties:
+  data:
+    description: Array of logo objects for the current page.
+    type: array
+    items:
+      $ref: ./LogoSummary.yaml
+  pagination:
+    description: Pagination metadata.
+    type: object
+    required:
+      - page
+      - limit
+      - total
+    properties:
+      page:
+        description: The current page number (1-based).
+        type: integer
+        example: 1
+      limit:
+        description: Maximum number of items returned per page.
+        type: integer
+        example: 20
+      total:
+        description: Total number of logos owned by the authenticated user.
+        type: integer
+        example: 3

--- a/openapi/paths/assets-logo.yaml
+++ b/openapi/paths/assets-logo.yaml
@@ -65,3 +65,52 @@ post:
                 detail: 'Only image/png, image/jpeg, and image/svg+xml are accepted. Received: image/gif.'
     '401':
       $ref: ../components/responses/Unauthorized.yaml
+
+get:
+  tags:
+    - Assets
+  summary: List logos
+  description: Returns a paginated list of all logo assets owned by the authenticated user, ordered by `createdAt` descending. To obtain a download URL for a specific logo, call `GET /assets/logo/{logoId}`.
+  operationId: listLogos
+  security:
+    - firebase_jwt: []
+    - api_key: []
+  parameters:
+    - name: page
+      in: query
+      description: Page number to retrieve (1-based).
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+      example: 1
+    - name: limit
+      in: query
+      description: Number of items per page.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+      example: 20
+  responses:
+    '200':
+      description: Paginated list of logos.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/PaginatedLogos.yaml
+          example:
+            data:
+              - logoId: logo_xyz789
+                filename: company-logo.png
+                createdAt: '2026-02-18T12:00:00Z'
+              - logoId: logo_abc123
+                filename: brand-mark.svg
+                createdAt: '2026-01-10T09:30:00Z'
+            pagination:
+              page: 1
+              limit: 20
+              total: 2
+    '401':
+      $ref: ../components/responses/Unauthorized.yaml


### PR DESCRIPTION
## Summary

- Adds `GET /assets/logo` endpoint (`listLogos` operation) to the Assets tag
- Returns a paginated list of logo assets owned by the authenticated user, ordered by `createdAt` descending
- Introduces `LogoSummary` schema (metadata only — no pre-signed URLs) and `PaginatedLogos` envelope schema

## Test plan

- [ ] Run `npm test` — no errors or warnings
- [ ] Verify list response does not expose pre-signed URLs (callers use `GET /assets/logo/{logoId}` for that)
- [ ] Check pagination params (`page`, `limit`) behave consistently with other list endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)